### PR TITLE
Resolve GHSA-67mh-4wv8-2f99

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@types/alpinejs": "^3.13.10",
         "babel-jest": "^29.5.0",
         "brotli-size": "^4.0.0",
-        "esbuild": "0.17.19",
+        "esbuild": "^0.25.5",
         "gzip-size": "^7.0.0",
         "swiper": "^11.2.7"
     },


### PR DESCRIPTION
This PR resolves an issue reported by `npm audit` for `esbuild`. Specifically:

> esbuild  <=0.24.2
> Severity: moderate
> esbuild enables any website to send any requests to the development server and read the response - https://github.com/advisories/GHSA-67mh-4wv8-2f99
> No fix available
> node_modules/@thatonejustin/alpine-swiper/node_modules/esbuild
> node_modules/alpine-swiper/node_modules/esbuild
>   @thatonejustin/alpine-swiper  *
>   Depends on vulnerable versions of esbuild
>   node_modules/@thatonejustin/alpine-swiper
>   alpine-swiper  *
>  Depends on vulnerable versions of esbuild
>   node_modules/alpine-swiper`
  